### PR TITLE
Delete lastSeq from SecureStore when users deliberately remove connections

### DIFF
--- a/app/connections.tsx
+++ b/app/connections.tsx
@@ -16,7 +16,7 @@ import { ListRow } from '@/components/ui/ListRow'
 import { useWallet } from '@/context/WalletContext'
 import connectionStore, { type Connection } from '@/stores/ConnectionStore'
 import QRScanner from '@/components/QRScanner'
-import { useWalletConnection } from '@/context/WalletConnectionContext'
+import { useWalletConnection, lastSeqKey } from '@/context/WalletConnectionContext'
 
 interface PairingParams {
   [key: string]: string // required by Expo Router's UnknownInputParams
@@ -246,7 +246,10 @@ export default observer(function ConnectionsScreen() {
                           <Text style={[styles.trailingActionText, { color: colors.info }]}>{t('reconnect')}</Text>
                         </TouchableOpacity>
                         <TouchableOpacity
-                          onPress={() => connectionStore.remove(item.sessionId)}
+                          onPress={() => {
+                            void SecureStore.deleteItemAsync(lastSeqKey(item.sessionId))
+                            connectionStore.remove(item.sessionId)
+                          }}
                           style={[styles.trailingAction, { marginLeft: spacing.md }]}
                           activeOpacity={0.6}
                         >

--- a/app/connections.tsx
+++ b/app/connections.tsx
@@ -136,7 +136,7 @@ export default observer(function ConnectionsScreen() {
 
       ws.onopen = async () => {
         try {
-          const storedSeq = await SecureStore.getItemAsync(`wallet_pairing_lastseq_${conn.sessionId}`)
+          const storedSeq = await SecureStore.getItemAsync(lastSeqKey(conn.sessionId))
           const seq = storedSeq ? Number(storedSeq) + 1 : 1
           const payload = JSON.stringify({
             id: crypto.randomUUID(),

--- a/context/WalletConnectionContext.tsx
+++ b/context/WalletConnectionContext.tsx
@@ -18,7 +18,7 @@ export const IMPLEMENTED_METHODS = new Set([
 const NAV_TIMEOUT_MS      = 5  * 60 * 1000  // 5 min  — navigated away from pair screen
 const APP_STATE_TIMEOUT_MS = 12 * 60 * 1000  // 12 min — app backgrounded
 
-const lastSeqKey = (topic: string) => `wallet_pairing_lastseq_${topic}`
+export const lastSeqKey = (topic: string) => `wallet_pairing_lastseq_${topic}`
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Exports lastSeqKey from WalletConnectionContext so the SecureStore key format has a single source of truth
- Deletes wallet_pairing_lastseq_<sessionId> from SecureStore when a connection is removed

## Problem

When a user removed a connection, only the AsyncStorage entry was cleaned up. The corresponding SecureStore key tracking the last relay sequence number (wallet_pairing_lastseq_<sessionId>) was left behind indefinitely with no way to ever be cleared — the connection it belonged to no longer exists, so the key serves no purpose.