### PR TITLE
Show loading overlay instantly on tab switch

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1658,6 +1658,7 @@ const Browser = observer(function Browser() {
             androidHardwareAccelerationDisabled={false}
             onError={(e: any) => {
               e.preventDefault()
+              tabStore.clearSwitchLoading()
               if (e.nativeEvent?.url?.includes('favicon.ico') && activeTab?.url === kNEW_TAB_URL) return
               const code = e.nativeEvent?.code
               // Only handle native network errors (negative codes: DNS, TLS, timeout, etc.)
@@ -1717,6 +1718,8 @@ const Browser = observer(function Browser() {
               }
             }}
             onLoadEnd={(event: any) => {
+              // Target page has painted — drop the tab-switch loading overlay.
+              tabStore.clearSwitchLoading()
               // Suppress state updates while 402 payment is in flight — document.write
               // of the loading page fires onLoadEnd which re-renders and flickers the
               // spending authorization modal.
@@ -1759,6 +1762,19 @@ const Browser = observer(function Browser() {
             containerStyle={webviewContainerStyle}
             style={webviewStyle}
           />
+          {tabStore.switchLoading && (
+            <View
+              pointerEvents="none"
+              style={{
+                ...StyleSheet.absoluteFillObject,
+                backgroundColor: colors.background,
+                justifyContent: 'center',
+                alignItems: 'center'
+              }}
+            >
+              <ActivityIndicator size="large" />
+            </View>
+          )}
         </View>
       )
     }

--- a/stores/TabStore.tsx
+++ b/stores/TabStore.tsx
@@ -33,6 +33,11 @@ export class TabStore {
   activeTabId = 1
   showTabsView = false
   isInitialized = false // Add initialization flag
+  // True while a tab switch is waiting for the target page's first paint.
+  // Drives a full-screen loading overlay so the previous tab's content is
+  // never visible after the user taps a different tab.
+  switchLoading = false
+  private switchLoadingTimeout: ReturnType<typeof setTimeout> | null = null
   private nextId = 1
   private tabNavigationHistories: { [tabId: number]: { url: string; title: string }[] } = {} // Track navigation history per tab
   private tabHistoryIndexes: { [tabId: number]: number } = {} // Track current position in history per tab
@@ -146,12 +151,32 @@ export class TabStore {
       console.log(`setActiveTab(): Setting activeTabId=${id}`)
       this.activeTabId = id
       this.lastFocusedAt.set(id, Date.now())
+
+      // Raise the loading overlay in the same MobX commit as the active-tab
+      // change so the previous tab's page never flashes while the new page
+      // loads. Only for real web pages — the homepage (kNEW_TAB_URL) renders
+      // natively with no WebView load event that would clear the overlay.
+      const targetIsWebPage = targetTab.url !== kNEW_TAB_URL && targetTab.url.startsWith('http')
+      this.switchLoading = targetIsWebPage
+      if (this.switchLoadingTimeout) clearTimeout(this.switchLoadingTimeout)
+      if (this.switchLoading) {
+        this.switchLoadingTimeout = setTimeout(() => this.clearSwitchLoading(), 8000)
+      }
+
       this.saveActive().catch(e => console.error('saveActive failed', e))
     } else if (!targetTab) {
       console.warn(`setActiveTab(): Target tab ${id} not found`)
     } else {
       console.log(`setActiveTab(): Tab ${id} is already active, no change needed`)
     }
+  }
+
+  clearSwitchLoading() {
+    if (this.switchLoadingTimeout) {
+      clearTimeout(this.switchLoadingTimeout)
+      this.switchLoadingTimeout = null
+    }
+    this.switchLoading = false
   }
 
   /** Evict the oldest non-active tab when tab count exceeds MAX_TABS. */


### PR DESCRIPTION
## Summary
- Tapping a tab to switch back to it briefly showed the *previous* page while the new URL re-loaded into the shared WebView.
- Now a full-screen loading overlay is raised the instant the active tab changes, so the old page never flashes.

## Changes
- `stores/TabStore.tsx`: new `switchLoading` observable set **synchronously** inside `setActiveTab` (same MobX commit as `activeTabId`), plus `clearSwitchLoading()` and an 8s safety timeout. Only raised for real web pages — homepage (`about:blank`) renders natively with no WebView load event.
- `app/index.tsx`: render an absolute-fill overlay (`colors.background` + `ActivityIndicator`) over the WebView while `switchLoading` is true; clear it on `onLoadEnd` and `onError`.

## Why it removes the flash
`switchLoading` and `activeTabId` mutate in one synchronous action → MobX batches into a single observer re-render → the overlay paints in the same frame as the new tab's source swap. No intermediate frame can show the old page.

## Test plan
- [x] Logic verified by running the real `TabStore` in a Node harness: overlay raised synchronously on switch to a web tab; cleared on load end; not raised for same-tab or homepage switches; raised again navigating back to a web tab (6/6 pass).
- [x] Device/sim check: open two web tabs, switch between them, confirm overlay appears immediately with no old-page flash; confirm homepage tab shows no overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)