### PR TITLE
perf(402): payment orchestration wins + arcade broadcast handling (rebased on #107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Once a wallet is active the app switches to **Web3 mode** and BSV-enabled web ap
 | `npm start`            | Start the Expo dev server (`expo start --dev-client`)   |
 | `npm run android`      | Start on a connected Android device / emulator          |
 | `npm run ios`          | Start on a connected iOS device / simulator             |
+| `npm run ios-run`      | Build (RN from source) + launch the iOS dev-client on the simulator |
 | `npm run web`          | Start the web version                                   |
 | `npm run lint`         | Run ESLint                                              |
 | `npm run lint:fix`     | Run ESLint with auto-fix                                |
@@ -267,7 +268,7 @@ The app uses **EAS Build** to create native binaries locally. You need the EAS C
 ### iOS (macOS only)
 
 ```bash
-# Create a development build
+# Create a development build (EAS local — simulator dev-client)
 npm run ios-dev-build
 
 # The build produces a .tar.gz archive. Double-click it to extract the .app,
@@ -276,6 +277,29 @@ npm run ios-dev-build
 # Start the dev server and connect
 npm run ios
 ```
+
+For a faster local iterate-on-native loop (compiles, installs, and launches on
+a booted simulator in one step, without the EAS packaging), use:
+
+```bash
+npm run ios-run
+```
+
+> **Why `RCT_USE_PREBUILT_RNCORE=0`?** This repo defaults to Expo's **prebuilt
+> React-Core** (`ios/Podfile`) for faster release builds. The prebuilt
+> framework omits the RN dev-support symbols that **`expo-dev-client`** /
+> `expo-dev-menu` link against (packager connection, Hermes inspector), so a
+> dev-client build against the prebuilt core **fails to link**. Dev-client
+> builds must therefore build React Native **from source**:
+> - `npm run ios-run` sets `RCT_USE_PREBUILT_RNCORE=0` for you.
+> - `npm run ios-dev-build` / `ios-dev-physical` inherit it from the matching
+>   EAS profile in `eas.json` (`env.RCT_USE_PREBUILT_RNCORE = "0"`).
+> - Production builds keep the prebuilt core (they don't ship the dev menu), so
+>   release build times are unaffected.
+>
+> If you run `npx expo run:ios` or `pod install` directly, export
+> `RCT_USE_PREBUILT_RNCORE=0` first, or the dev-client link will fail with
+> `Undefined symbols … RCTPackagerConnection / inspector_modern`.
 
 ### Android
 

--- a/__tests__/arcadeBroadcastProvider.test.ts
+++ b/__tests__/arcadeBroadcastProvider.test.ts
@@ -1,0 +1,79 @@
+import { handleArcResponse } from '@/services/arcadeBroadcastProvider'
+
+describe('handleArcResponse', () => {
+  const txids = ['abc123']
+
+  it('treats Arcade RECEIVED (HTTP 202) as success', () => {
+    const result = handleArcResponse(
+      'Arcade',
+      { ok: true, status: 202 },
+      { txid: txids[0], txStatus: 'RECEIVED' },
+      txids
+    )
+    expect(result.status).toBe('success')
+    expect(result.txid).toBe(txids[0])
+    expect(result.doubleSpend).toBeUndefined()
+    expect(result.serviceError).toBeUndefined()
+  })
+
+  it.each([
+    'STORED',
+    'SENT_TO_NETWORK',
+    'ACCEPTED_BY_NETWORK',
+    'SEEN_ON_NETWORK',
+    'SEEN_MULTIPLE_NODES',
+    'MINED',
+    'IMMUTABLE'
+  ] as const)('treats %s as success when response.ok', (txStatus) => {
+    const result = handleArcResponse(
+      'Arcade',
+      { ok: true, status: 200 },
+      { txid: txids[0], txStatus },
+      txids
+    )
+    expect(result.status).toBe('success')
+  })
+
+  it('marks double-spend statuses without success', () => {
+    for (const txStatus of ['DOUBLE_SPEND_ATTEMPTED', 'SEEN_IN_ORPHAN_MEMPOOL'] as const) {
+      const result = handleArcResponse(
+        'Arcade',
+        { ok: true, status: 200 },
+        { txid: txids[0], txStatus },
+        txids
+      )
+      expect(result.status).toBe('error')
+      expect(result.doubleSpend).toBe(true)
+    }
+  })
+
+  it('marks REJECTED and non-ok HTTP as serviceError', () => {
+    const rejected = handleArcResponse(
+      'Arcade',
+      { ok: true, status: 200 },
+      { txid: txids[0], txStatus: 'REJECTED' },
+      txids
+    )
+    expect(rejected.status).toBe('error')
+    expect(rejected.serviceError).toBe(true)
+
+    const httpErr = handleArcResponse(
+      'Arcade',
+      { ok: false, status: 500 },
+      { txid: txids[0], txStatus: 'RECEIVED' },
+      txids
+    )
+    expect(httpErr.status).toBe('error')
+    expect(httpErr.serviceError).toBe(true)
+  })
+
+  it('treats missing txStatus with ok response as success (built-in ARC parity)', () => {
+    const result = handleArcResponse(
+      'TaalArc',
+      { ok: true, status: 200 },
+      { txid: txids[0] },
+      txids
+    )
+    expect(result.status).toBe('success')
+  })
+})

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "BSV Browser",
     "slug": "bsv-browser",
     "scheme": "bsv-browser",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "userInterfaceStyle": "automatic",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -76,6 +76,17 @@ import { mark } from '@/utils/perfMarks'
 /*                                   CONSTS                                   */
 /* -------------------------------------------------------------------------- */
 
+// BRC-100 methods that must NOT pay the InteractionManager yield tax on the
+// CWI hot path. L0 = fixed in-memory answers; L1 = pure crypto (no storage,
+// no permission mutation). These are what dApps storm on page load.
+const CWI_NO_YIELD = new Set<string>([
+  // L0 — free
+  'getVersion', 'getNetwork', 'isAuthenticated', 'waitForAuthentication',
+  // L1 — crypto
+  'getPublicKey', 'createHmac', 'verifyHmac', 'createSignature', 'verifySignature',
+  'encrypt', 'decrypt'
+])
+
 function getInjectableJSMessage(message: any = {}) {
   const messageString = JSON.stringify(message)
   return `
@@ -1268,7 +1279,16 @@ const Browser = observer(function Browser() {
       // chrome animations on iPhone SE. InteractionManager.runAfterInteractions
       // resolves immediately when the JS thread is idle, so auto-approved micros
       // pay no extra cost.
-      await new Promise<void>(resolve => InteractionManager.runAfterInteractions(() => resolve()))
+      //
+      // Tiered scheduling: L0 (fixed in-memory answers) and L1 (crypto) methods
+      // skip the yield entirely. dApps fire storms of getPublicKey / getNetwork /
+      // isAuthenticated on page load; making each wait a frame for
+      // runAfterInteractions adds latency for no benefit — they touch no storage
+      // and don't contend with chrome the way an L3 createAction does. Only
+      // L2 (reads) and L3 (mutations) keep the yield.
+      if (!CWI_NO_YIELD.has(msg.call)) {
+        await new Promise<void>(resolve => InteractionManager.runAfterInteractions(() => resolve()))
+      }
 
       const perfEnd = mark(`cwi.${msg.call}`)
       try {

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -513,16 +513,13 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
       const threshold = autoApproveThresholdRef.current
       const now = Date.now()
       const sinceLastMs = now - lastAutoApproveTime
-      console.log(
-        `[spend-auth] requestID=${requestID} sats=${spending.satoshis} threshold=${threshold} ` +
-          `sinceLastMs=${sinceLastMs} cooldownMs=${AUTO_APPROVE_COOLDOWN_MS} ` +
-          `eligible=${threshold > 0 && spending.satoshis <= threshold} cooldownOk=${sinceLastMs >= AUTO_APPROVE_COOLDOWN_MS} ` +
-          `managerBound=${!!managersRef.current.permissionsManager}`
-      )
+      // Logging gated behind __DEV__: an unconditional console.log here flushes
+      // over the JS↔native bridge on every spend request — i.e. on the payment
+      // hot path — and shows up as jank under any burst of micropayments.
       if (threshold > 0 && spending.satoshis <= threshold) {
         if (sinceLastMs >= AUTO_APPROVE_COOLDOWN_MS) {
           lastAutoApproveTime = now
-          console.log(`[spend-auth] AUTO-APPROVING requestID=${requestID}`)
+          if (__DEV__) console.log(`[spend-auth] AUTO-APPROVING requestID=${requestID} sats=${spending.satoshis}`)
           managersRef.current.permissionsManager?.grantPermission({
             requestID,
             ephemeral: true,
@@ -530,9 +527,9 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({ children =
           })
           return
         }
-        console.log(`[spend-auth] cooldown blocked → manual modal requestID=${requestID}`)
-      } else {
-        console.log(`[spend-auth] not eligible → manual modal requestID=${requestID}`)
+        if (__DEV__) console.log(`[spend-auth] cooldown blocked → manual modal requestID=${requestID}`)
+      } else if (__DEV__) {
+        console.log(`[spend-auth] not eligible → manual modal requestID=${requestID} sats=${spending.satoshis} threshold=${threshold}`)
       }
 
       spendingQueue.enqueue({

--- a/docs/402_PAYMENTS.md
+++ b/docs/402_PAYMENTS.md
@@ -33,7 +33,7 @@ Since WebView native navigations don't expose response headers, the payment hand
 
 1. **Read payment parameters** — extract `x-bsv-sats` (amount) and `x-bsv-server` (server identity key) from headers, or probe the URL if headers were unavailable.
 2. **Derive a payment key** — call `wallet.getPublicKey()` with BRC-29 protocol ID `[2, '3241645161d8']`, a random `derivationPrefix` and `derivationSuffix`, and the server's identity key as counterparty.
-3. **Build the transaction** — call `wallet.createAction()` with a P2PKH output locked to the derived key's hash. The `customInstructions` field carries the derivation parameters so the server can derive the matching private key.
+3. **Build and broadcast the transaction** — call `wallet.createAction()` with a P2PKH output locked to the derived key's hash and `acceptDelayedBroadcast: false`. The `customInstructions` field carries the derivation parameters so the server can derive the matching private key. Undelayed mode posts to Arcade (or failover broadcasters) before the call returns; Arcade's immediate `RECEIVED` / `202` is treated as broadcast success (later SSE `SEEN_ON_NETWORK` is not required for the paid retry).
 4. **Retry the request** — re-fetch the original URL with five payment headers:
 
 ```

--- a/docs/WALLET_PERFORMANCE_ARCHITECTURE.md
+++ b/docs/WALLET_PERFORMANCE_ARCHITECTURE.md
@@ -1,0 +1,397 @@
+# Wallet Performance Architecture Review
+
+**Date:** 2026-07-21  
+**Branch context:** `feat/native-ecdsa-speedup` (and current mainline wallet paths)  
+**Scope:** Paying, status updates, receiving funds, and BRC-100 / CWI method processing  
+**Goal:** Blazing-fast wallet operations on mobile (iOS/Android React Native + Expo)
+
+This document captures an architecture-grounded performance review of BSV Browser’s wallet stack. It is intentionally recommendation-focused (not an implementation plan). For implementation, turn selected items into OpenSpec changes with measurable latency budgets.
+
+---
+
+## Executive summary
+
+The app already has strong foundations for a mobile Web3 wallet:
+
+- Early `react-native-quick-crypto` + fast ECDSA (Metro alias + optional native ufsecp)
+- SQLite `StorageProvider` (`StorageExpoSQLite`) with SQL-native list paths
+- Auto-approve micropayments, 402 coalescing/cache, delayed-vs-undelayed broadcast awareness
+- ARC SSE monitor with carefully patched tasks and deferred cold-start start
+- `WalletManagersContext` to stop browser re-renders on every SSE tick
+
+**Remaining bottlenecks are mostly architectural latency on the hot path**, not “make ECDSA 10% faster.” Crypto is necessary but no longer sufficient. Bridge, permissions, two-phase sign, exclusive SQLite, monitor contention, and network mode dominate user-perceived pay/status latency.
+
+---
+
+## Current architecture
+
+### Stack overview
+
+| Layer | Location / package | Role |
+| ----- | ------------------ | ---- |
+| WebView CWI | `utils/webview/cwiProvider.ts`, `app/index.tsx` | BRC-100 provider over `postMessage` / `injectJavaScript` |
+| 402 payments | `utils/webview/bsvPaymentHandler.ts` | Merchant micropay: derive keys → `createAction` → undelayed broadcast → paid GET |
+| PeerPay | `app/payments.tsx`, `utils/peerpay/outbox.ts` | MessageBox send/receive + durable outbox |
+| Pairing RPC | `context/WalletConnectionContext.tsx` | Encrypted WS relay of BRC-100 methods |
+| Permissions | `@bsv/wallet-toolbox-mobile` `WalletPermissionsManager` | Originator gating, spending auth, metadata encrypt |
+| Wallet core | toolbox `Wallet` / `WalletSigner` / `SimpleWalletManager` | Action build, sign, process |
+| Storage | `storage/StorageExpoSQLite.ts` | expo-sqlite backend extending `StorageProvider` |
+| Services | `services/walletServiceConfig.ts`, arcade broadcast providers | ARC, WoC, Chaintracks, multi-broadcaster |
+| Monitor | `context/WalletContext.tsx` + toolbox `Monitor` | SSE status, send-waiting, proofs, header poll |
+| Crypto | `index.js`, `utils/crypto/*`, `modules/native-secp256k1` | Hashes/AES + secp256k1 sign/verify |
+
+### Boot and provider tree
+
+```
+index.js
+  → quick-crypto install
+  → installFastEcdsa()   # native preferred, noble fallback
+  → Expo Router
+
+app/_layout.tsx providers (simplified)
+  LocalStorage → User → ExchangeRate → Wallet → BrowserMode → Theme …
+```
+
+Wallet construction lives primarily in `context/WalletContext.tsx` (`buildWallet` / mnemonic recover / SQLite migrate / permissions / monitor).
+
+### Payment / BRC-100 hot path
+
+```
+┌──────────────┐   postMessage    ┌────────────────────┐
+│ WebView CWI  │ ───────────────► │ app/index handleMsg│
+│ / 402 / Pay  │                  │ + InteractionManager│
+└──────────────┘                  └─────────┬──────────┘
+                                            │
+                                            ▼
+                              ┌─────────────────────────────┐
+                              │ WalletPermissionsManager    │
+                              │ • basket/label checks       │
+                              │ • encryptActionMetadata     │
+                              │ • always signAndProcess=false│
+                              │ • spending auth / auto-grant│
+                              │ • then underlying.signAction│
+                              └─────────────┬───────────────┘
+                                            │
+                    ┌───────────────────────┼───────────────────────┐
+                    ▼                       ▼                       ▼
+           ┌────────────────┐     ┌──────────────────┐     ┌────────────────┐
+           │ Wallet/Signer  │     │ StorageExpoSQLite│     │ Services/ARC   │
+           │ ECDSA (native) │     │ exclusive txn    │     │ + WoC/CT       │
+           │ KeyDeriver     │     │ multi round-trips│     │ broadcast wait │
+           └────────────────┘     └──────────────────┘     └───────┬────────┘
+                                                                    │
+                                            ┌───────────────────────┘
+                                            ▼
+                                   ┌────────────────┐
+                                   │ Monitor (SSE)  │
+                                   │ serial runOnce │
+                                   │ ~every few sec │
+                                   └────────────────┘
+```
+
+### End-to-end cost of a typical BRC-100 `createAction`
+
+1. Bridge serialize/parse (`postMessage`)
+2. Optional animation yield (`InteractionManager.runAfterInteractions`)
+3. PermissionsManager metadata encrypt + permission lookups
+4. Storage `createAction` (UTXO select + exclusive SQLite transaction)
+5. Sign — manager forces `signAndProcess: false`, then a second `signAction` pass
+6. Auto-approve path currently re-reads AsyncStorage on **every** spend request
+7. Broadcast RTT when `acceptDelayedBroadcast: false` (required for 402 correctness)
+8. Bridge inject result (`injectJavaScript`)
+9. Later: SSE/monitor promotes status → `txStatusVersion++` → UI refresh
+
+---
+
+## Strengths to preserve
+
+| Area | Why it matters |
+| ---- | -------------- |
+| Early `quick-crypto` + fast ECDSA Metro alias | Hash/AES/ECDSA off pure-JS for sign-heavy paths |
+| Auto-approve + 402 in-flight coalesce + payment cache | Correct “instant micro” UX primitives |
+| `acceptDelayedBroadcast: false` only for 402 | Correctness for merchants; do not apply globally |
+| SQL-native `listOutputs` / `listActions` | Better than IDB-style cursor filtering |
+| Monitor patches (NewHeader cadence, ReviewProvenTxs removed, QuietEventSource) | Avoids JS-thread death by logging/polling |
+| Deferred `monitor.startTasks()` | Protects cold start |
+| `WalletManagersContext` | Stops browser tree thrashing on SSE ticks |
+| Dev perf tooling (`utils/perf.ts`, monitor task timers, JS stall watchdog) | Enables phase-level diagnosis |
+
+---
+
+## Recommendations (priority order)
+
+### P0 — Biggest wins for “feels instant”
+
+#### 1. Tier BRC-100 methods (scheduling + permissions policy)
+
+Today **every** CWI call takes the same path: yield → `permissionsManager[method]` → inject.
+
+Split methods into latency classes:
+
+| Tier | Methods | Policy |
+| ---- | ------- | ------ |
+| **L0 — free** | `getVersion`, `getNetwork`, `isAuthenticated`, `waitForAuthentication` | No yield, no storage, fixed answers from memory |
+| **L1 — crypto** | `getPublicKey`, `createHmac`/`verifyHmac`, `createSignature`/`verifySignature`, `encrypt`/`decrypt` | No `InteractionManager`; no SQLite; keep on JS thread only if native crypto is warm |
+| **L2 — read** | `listOutputs`, `listActions`, `listCertificates`, `getHeight` | Short yield only if UI animating; prefer cached UTXO/balance |
+| **L3 — mutate** | `createAction`, `signAction`, `internalizeAction`, cert acquire | Full path + permission + exclusive txn |
+
+**Why:** dApps often call `getPublicKey` / `getNetwork` / `listOutputs` in a storm before paying. Those should not pay the same tax as `createAction`.
+
+#### 2. Kill the auto-approve AsyncStorage read on every spend
+
+In `spendingAuthorizationCallback` (`WalletContext.tsx`), **every** request does:
+
+```ts
+const stored = await AsyncStorage.getItem(AUTO_APPROVE_STORAGE_KEY)
+```
+
+That is a disk/bridge hop **before** grant. `autoApproveThresholdRef` already exists — make it **write-through** from settings UI and trust the ref at request time. Optionally revalidate in background on app resume.
+
+This alone shaves real milliseconds off every auto-approved micro.
+
+#### 3. Collapse two-phase create+sign for trusted / auto-approved spends
+
+`WalletPermissionsManager.createAction` always forces `signAndProcess: false`, builds a signable tx, gates spend, then `signAction`. That is intentional for auth UX, but it **doubles storage/signing orchestration** for the auto-approve path.
+
+Options (increasing aggressiveness):
+
+- After ephemeral grant, call `signAction` immediately without re-entering extra encrypt/permission layers (ensure no third pass).
+- For admin/auto-approved originators under threshold, short-circuit to underlying wallet with `signAndProcess: true` (admin-only API already exists in the manager).
+- App-level “micropayment engine” that, once originator+amount is pre-authorized, builds against storage with fewer manager steps (still audit permissions carefully).
+
+This is the largest structural cut on pay latency after crypto.
+
+#### 4. In-memory UTXO / balance cache in front of SQLite
+
+`listOutputs` (balance, change selection, many dApps) hits SQL every time. On mobile:
+
+- Maintain a **spendable change cache** (basket `default` / change) invalidated on `createAction` / `internalizeAction` / SSE status that spends or confirms.
+- Serve balance + common `listOutputs` from cache; refresh async.
+- Keep cache process-local (not secret; SecureStore not required).
+
+This speeds **pay preparation**, **status UI**, and chatty BRC-100 reads.
+
+---
+
+### P1 — Storage and concurrency
+
+#### 5. SQLite PRAGMAs on open
+
+No WAL / busy timeout was found in app storage. On `migrate()` / first open, set:
+
+```sql
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA busy_timeout=5000;
+PRAGMA temp_store=MEMORY;
+PRAGMA cache_size=-8000;  -- ~8MB, tune by device tier
+```
+
+`withExclusiveTransactionAsync` already serializes writes; WAL helps concurrent **reads** from monitor vs UI, and reduces fsync cost on commit.
+
+#### 6. Reduce exclusive-txn surface and N+1
+
+`transaction()` swaps `this.db` onto the exclusive connection for the whole scope — good for correctness, bad if `createAction` holds it while the monitor tries to write events.
+
+- Keep exclusive scopes **tight** (only multi-statement atomic units).
+- Avoid per-row script validation when `noScript: true` (list paths already skip; extend to other finders used in selection).
+- Add composite indexes aligned to hot filters, for example:
+  - `outputs(userId, spendable, basketId)`
+  - `transactions(userId, status, created_at)`
+  - `proven_tx_reqs(status, attempts)`
+
+#### 7. Don’t SQLite-log every monitor task
+
+`Monitor.logEvent` inserts a row for many task runs. Under SSE chatter that is pure write amplification on the same DB as payments.
+
+- Sample or drop `MonitorCallHistory`-style noise (details already truncated in places).
+- Persist only failures + status transitions the UI cares about.
+- Debounce `setTxStatusVersion` (e.g. 100–250 ms coalesce) so SSE bursts don’t thrash React.
+
+#### 8. Yield between monitor tasks (or pause during L3)
+
+`runOnce()` runs due tasks **back-to-back** on the JS thread. Dev instrumentation already flags >50 ms tasks. Next steps:
+
+- Between tasks: `await new Promise(r => setTimeout(r, 0))` (or InteractionManager) so a payment `createAction` can interleave.
+- Or pause the monitor while an L3 op is in flight (simple mutex).
+
+---
+
+### P1 — Pay / receive product paths
+
+#### 9. Dual broadcast modes by UX class
+
+| Flow | Broadcast | Why |
+| ---- | --------- | --- |
+| 402 / merchant must see tx now | `acceptDelayedBroadcast: false` | Correctness |
+| PeerPay send, in-app transfer, non-critical | delayed + outbox/SSE | Returns to user sooner |
+| Status UI | trust SSE first, poll only on resume | Battery + CPU |
+
+Keep undelayed for 402. Ensure PeerPay/UI payments do not accidentally inherit undelayed semantics.
+
+#### 10. Parallelize 402 pre-work
+
+`_doPayment` does sequential `getPublicKey` (derived) then `getPublicKey` (identity). Those can run **in parallel**. Same for any “derive + identity + rate” setup before `createAction`.
+
+Once auto-approve is guaranteed for an origin, pre-warm little more than a session-cached identity key.
+
+#### 11. PeerPay outbox storage model
+
+Outbox is one JSON blob in `key_value_store` rewritten on every save/retry (`utils/peerpay/outbox.ts`). Fine for a few entries; not for active users.
+
+- Table `peerpay_outbox` with indexed status, or one key per entry.
+- On send success: update row, don’t rewrite whole array.
+- Background retry when NetInfo flips online instead of only manual retry.
+
+#### 12. Receive path: optimistic internalize + background reconcile
+
+Receiving is network-bound (MessageBox list → internalize → storage). To feel instant:
+
+- Show pending inbox from last poll immediately.
+- Internalize in background with progress toast.
+- Don’t block the list UI on full `listIncomingPayments` every focus — SWR-style cache with last-seen message id if the service supports it.
+
+---
+
+### P2 — Crypto and key lifecycle (after ECDSA)
+
+#### 13. Finish the native ECDSA story and measure real-device path
+
+Ensure **release builds always report `backend: native`**, and measure full `createAction` (not just sign ops). Pure-JS can still dominate: BIP39 PBKDF2, BigInt-heavy BEEF merge, script assembly.
+
+#### 14. Mnemonic unlock is a cold-start tax
+
+`recoverMnemonicWallet` does PBKDF2 + BIP32 on the JS thread (already perf-logged). Options:
+
+- Cache **primary key material** in SecureStore after first successful unlock so daily open skips PBKDF2.
+- Use native PBKDF2 (quick-crypto) if not already on that path.
+- Lazy: open DB + answer L0 CWI methods before full `SimpleWalletManager` auth completes (harder; large UX win for dApps that only call `getVersion` on load).
+
+#### 15. Key derivation caching
+
+`getPublicKey` for the same `(protocolID, keyID, counterparty)` is common in 402/BRC-29. Session LRU (bounded, cleared on logout) removes repeated EC work even with native secp.
+
+---
+
+### P2 — Bridge and architecture shape
+
+#### 16. Slim the CWI response path for large payloads
+
+`listActions` / BEEF-heavy results → `JSON.stringify` → `injectJavaScript` is expensive. Mitigations:
+
+- Encourage dApps to use pagination + `returnTXIDOnly` where possible (docs / sample apps).
+- Cap default list sizes in the provider when args omit limits.
+- For huge results, multi-message stream or temp-file handle (only if both sides are controlled).
+
+#### 17. Serialize L3, parallelize L0–L2
+
+If two `createAction`s run concurrently, exclusive SQLite + change selection races. Introduce a small **wallet operation scheduler**:
+
+- L0–L2: concurrent
+- L3: single-flight queue (FIFO, or priority for user-initiated UI pay over background)
+
+#### 18. Permissions grant cache
+
+First protocol/spend grant is human-latency bound (OK). Subsequent grants should be pure memory:
+
+- `Map<originator, Set<protocol|basket|spend cap>>` loaded once from storage at wallet build
+- Avoid re-querying permission tables on every `getPublicKey` / small action if the manager does that today
+
+Many `seek*` flags are already disabled — good. Audit remaining DB hits inside `ensureSpendingAuthorization` / protocol checks.
+
+#### 19. Split WalletContext further (status plane)
+
+Managers are already split via `WalletManagersContext`. Next: a **TxStatusContext** that only exposes `txStatusVersion` / last statuses so payments screens don’t couple to permission queues. Reduces JS work during SSE storms while paying.
+
+---
+
+## Target latency budgets
+
+Use these as product bars when instrumenting on device (native ECDSA build).
+
+| Operation | Feels fast | Stretch |
+| --------- | ---------- | ------- |
+| L0 CWI | &lt; 5 ms | &lt; 2 ms |
+| Auto-approved micro `createAction` (local sign, delayed broadcast) | &lt; 80–120 ms | &lt; 50 ms |
+| Same with undelayed broadcast | RTT + 50–100 ms local | RTT + 30 ms |
+| `listOutputs` balance (warm cache) | &lt; 10 ms | &lt; 5 ms |
+| Status flip after SSE | &lt; 100 ms UI | frame-aligned debounce |
+| Receive list (warm) | &lt; 50 ms paint | optimistic |
+
+### Instrumentation guidance
+
+Extend existing `perf.track` / `mark('cwi.*')` with **phase labels**:
+
+- `perm`
+- `storage.create`
+- `sign`
+- `broadcast`
+- `bridge.out`
+
+Without phase timing, optimizations will chase the wrong layer.
+
+---
+
+## Suggested attack order
+
+If formalizing work (OpenSpec or plans):
+
+1. **Instrument** `createAction` phases + CWI p50/p95 on device (native ECDSA build).
+2. **L0/L1 fast path** + auto-approve ref-only + parallel 402 key derives.
+3. **UTXO cache** + SQLite PRAGMAs/indexes.
+4. **Auto-approved single-pass sign** (collapse PermissionsManager two-phase).
+5. **Monitor yield/mutex + logEvent diet + txStatus debounce**.
+6. **PeerPay outbox table + online retry**.
+7. **Mnemonic unlock cache** for cold start.
+
+---
+
+## What not to do first
+
+- Rewrite storage off SQLite (not the core issue).
+- Move the full toolbox into a native module (huge cost; only if phase timings prove JS orchestration irreducible).
+- Turn off permissions for all dApps (security regression).
+- Make every payment undelayed broadcast (feels slower; more fragile offline).
+
+---
+
+## Key files reference
+
+| File | Role |
+| ---- | ---- |
+| `context/WalletContext.tsx` | Wallet build, permissions callbacks, monitor, auto-approve, status version |
+| `app/index.tsx` | CWI message router, InteractionManager yield, 402 entry |
+| `utils/webview/cwiProvider.ts` | Injected `window.CWI` BRC-100 surface |
+| `utils/webview/bsvPaymentHandler.ts` | 402 payment orchestration |
+| `utils/peerpay/outbox.ts` | Durable outbound PeerPay tokens |
+| `storage/StorageExpoSQLite.ts` | SQLite provider, exclusive transactions |
+| `storage/methods/listOutputsSql.ts` | SQL listOutputs |
+| `storage/methods/listActionsSql.ts` | SQL listActions |
+| `services/walletServiceConfig.ts` | ARC / Chaintracks / WoC options |
+| `utils/walletMonitor.ts` | NewHeader poll cadence / backoff |
+| `utils/crypto/*` | Fast ECDSA install + backends |
+| `utils/perf.ts` | Dev JS-thread span instrumentation |
+| `context/WalletConnectionContext.tsx` | Paired desktop/session BRC-100 RPC |
+| `app/payments.tsx` | PeerPay UI send/receive |
+| `docs/NOWAB_IMPLEMENTATION.md` | Self-custodial wallet overview |
+
+Related prior notes:
+
+- `GROK_REVIEW.md` — broader “super fast browser” audit (chrome, tabs, re-renders, bridge)
+- `scripts/perf/results-diff.md` — earlier browser-perf harness deltas
+- `docs/superpowers/plans/2026-07-21-native-ecdsa-speedup.md` — native ECDSA implementation plan
+
+---
+
+## Bottom line
+
+The architecture is a solid **WebView substrate → PermissionsManager → toolbox Wallet → SQLite → ARC/SSE** pipeline.
+
+“Blazing” wallet ops will not come from one more crypto microbench alone. They come from:
+
+1. **Not treating every BRC-100 method like `createAction`**
+2. **Not paying disk + two-phase sign + exclusive DB + monitor contention on the micro path**
+3. **Caching read models (UTXOs, grants, identity keys) aggressively**
+4. **Using network wait only when the payment product actually requires it**
+
+Native ECDSA is the right foundation. The next biggest structural levers are **tiered CWI**, an **auto-approve path that skips re-auth disk and two-phase sign**, then **UTXO/SQLite/monitor contention**.

--- a/eas.json
+++ b/eas.json
@@ -10,11 +10,17 @@
       "distribution": "internal",
       "ios": {
         "simulator": true
+      },
+      "env": {
+        "RCT_USE_PREBUILT_RNCORE": "0"
       }
     },
     "dev-physical": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "RCT_USE_PREBUILT_RNCORE": "0"
+      }
     },
     "preview-apk": {
       "distribution": "internal",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "BSV Browser - Enabling identity, micropayments, and use of BSV websites on mobile devices",
   "author": "BSV Association",
   "main": "index.js",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "license": "Open BSV",
   "scripts": {
     "start": "expo start --dev-client",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ios-dev-build": "eas build --profile development --platform ios --local --verbose-logs --build-logger-level trace",
     "ios-dev-physical": "eas build --profile dev-physical --platform ios --local --verbose-logs --build-logger-level trace",
     "ios": "expo start --dev-client --ios",
+    "ios-run": "RCT_USE_PREBUILT_RNCORE=0 npx expo run:ios",
     "ios-build-for-app-store": "eas build --profile production --platform ios --local --verbose-logs --build-logger-level trace",
     "web": "expo start --web",
     "lint": "expo lint",

--- a/services/arcadeBroadcastProvider.ts
+++ b/services/arcadeBroadcastProvider.ts
@@ -5,13 +5,27 @@ import type {
 } from '@bsv/wallet-toolbox-mobile/out/src/sdk'
 
 /**
+ * ARC intermediate statuses that still mean "accepted for relay".
+ * Arcade often replies immediately with RECEIVED (HTTP 202); SEEN_* / MINED
+ * typically arrive later via SSE. The toolbox's built-in ARC provider treats any
+ * non-double-spend 2xx as success — match that so we do not fail over to WoC
+ * after Arcade already accepted the tx.
+ */
+const ARC_DOUBLE_SPEND_STATUSES = new Set([
+  'DOUBLE_SPEND_ATTEMPTED',
+  'SEEN_IN_ORPHAN_MEMPOOL'
+])
+
+/**
  * Shared response handling for ARC-compatible services (Arcade, Taal, GorillaPool).
  * Maps txStatus to the correct PostTxResultForTxid fields.
+ *
+ * Exported for unit tests.
  */
-function handleArcResponse(
+export function handleArcResponse(
   serviceName: string,
-  response: Response,
-  data: any,
+  response: { ok: boolean; status: number },
+  data: { txid?: string; txStatus?: string },
   txids: string[]
 ): PostTxResultForTxid {
   const txResult: PostTxResultForTxid = {
@@ -24,15 +38,12 @@ function handleArcResponse(
       httpStatus: response.status
     }]
   }
-  if (data.txStatus === 'DOUBLE_SPEND_ATTEMPTED') {
+  if (data.txStatus && ARC_DOUBLE_SPEND_STATUSES.has(data.txStatus)) {
     txResult.doubleSpend = true
-  } else if (
-    response.ok &&
-    (data.txStatus === 'SEEN_ON_NETWORK' ||
-      data.txStatus === 'SEEN_MULTIPLE_NODES' ||
-      data.txStatus === 'MINED' ||
-      !data.txStatus)
-  ) {
+  } else if (response.ok && data.txStatus !== 'REJECTED') {
+    // RECEIVED / STORED / SENT_TO_NETWORK / ACCEPTED_BY_NETWORK / SEEN_* / MINED
+    // all mean the broadcaster accepted the tx. Page-load 402 must not wait for
+    // SSE SEEN_ON_NETWORK before treating the post as successful.
     txResult.status = 'success'
   } else if (data.txStatus === 'REJECTED' || !response.ok) {
     txResult.serviceError = true

--- a/utils/webview/bsvPaymentHandler.ts
+++ b/utils/webview/bsvPaymentHandler.ts
@@ -2,6 +2,7 @@ import { PublicKey, Utils, Random } from '@bsv/sdk'
 import type { WalletInterface, WalletProtocol } from '@bsv/sdk'
 import { getErrorPage } from './errorPages'
 import { handleUrlDownload } from './downloadHandler'
+import { mark, measureAsync } from '@/utils/perfMarks'
 
 const BRC29_PROTOCOL_ID: WalletProtocol = [2, '3241645161d8']
 const HEADER_PREFIX = 'x-bsv-'
@@ -150,6 +151,7 @@ export class BsvPaymentHandler {
     }
 
     const satoshisRequired = Number.parseInt(satsHeader)
+    const endTotal = mark('402.total')
 
     try {
       const serverIdentityKey = serverHeader
@@ -159,17 +161,33 @@ export class BsvPaymentHandler {
       const derivationSuffix = btoa(timestamp)
       const originator = new URL(url).origin
 
-      const { publicKey: derivedPubKey } = await this.wallet.getPublicKey({
-        protocolID: BRC29_PROTOCOL_ID,
-        keyID: `${derivationPrefix} ${derivationSuffix}`,
-        counterparty: serverIdentityKey
-      }, originator)
+      // Derived (BRC-29) key and sender identity key are independent — derive
+      // them concurrently instead of serially. Each getPublicKey is an async
+      // KeyDeriver + (native) EC op; running them in parallel removes one full
+      // key-derivation round-trip from the pay hot path.
+      const [derivedRes, identityRes] = await Promise.all([
+        measureAsync('402.derive', () =>
+          this.wallet.getPublicKey({
+            protocolID: BRC29_PROTOCOL_ID,
+            keyID: `${derivationPrefix} ${derivationSuffix}`,
+            counterparty: serverIdentityKey
+          }, originator)),
+        measureAsync('402.identity', () =>
+          this.wallet.getPublicKey({ identityKey: true }, originator))
+      ])
+      const derivedPubKey = derivedRes.publicKey
+      const senderIdentityKey = identityRes.publicKey
 
       const pkh = PublicKey.fromString(derivedPubKey).toHash('hex') as string
 
-      const { publicKey: senderIdentityKey } = await this.wallet.getPublicKey({ identityKey: true }, originator)
-
-      let actionResult = await this.wallet.createAction({
+      // acceptDelayedBroadcast defaults to true in @bsv/sdk. That parks the
+      // signed tx as ProvenTxReq status `unsent` until TaskSendWaiting ages it
+      // (~7s) and the monitor posts it — so the merchant often cannot
+      // internalize until SSE/network status arrives. 402 micropayments need
+      // the tx on the network before we retry the paid GET, so force undelayed
+      // broadcast: createAction/signAction posts immediately and only returns
+      // after a successful broadcaster response (Arcade RECEIVED is enough).
+      let actionResult = await measureAsync('402.createAction', () => this.wallet.createAction({
         description: `Paid Content: ${new URL(url).pathname}`,
         outputs: [{
           satoshis: satoshisRequired,
@@ -184,9 +202,10 @@ export class BsvPaymentHandler {
         }],
         labels: ['402-payment'],
         options: {
-          randomizeOutputs: false
+          randomizeOutputs: false,
+          acceptDelayedBroadcast: false
         }
-      }, originator)
+      }, originator))
 
       // createAction may return an unsigned `signableTransaction` instead of a
       // final `tx` when signing is deferred. This is a documented, reachable
@@ -200,10 +219,11 @@ export class BsvPaymentHandler {
       // inputs and broadcasts. Without this, the payment tx stays created-but-
       // unsigned and the 402 page hangs forever on "Payment Required".
       if (!actionResult.tx && actionResult.signableTransaction) {
-        const signed = await this.wallet.signAction({
-          reference: actionResult.signableTransaction.reference,
-          spends: {}
-        }, originator)
+        const signed = await measureAsync('402.signAction', () => this.wallet.signAction({
+          reference: actionResult.signableTransaction!.reference,
+          spends: {},
+          options: { acceptDelayedBroadcast: false }
+        }, originator))
         actionResult = { ...actionResult, ...signed }
       }
 
@@ -222,12 +242,12 @@ export class BsvPaymentHandler {
         [`${HEADER_PREFIX}vout`]: vout
       }
 
-      const response = await fetch(url, {
+      const response = await measureAsync('402.paidGet', () => fetch(url, {
         headers: {
           ...paymentHeaders,
           Accept: 'text/html'
         } as HeadersInit
-      })
+      }))
 
       if (response.ok) {
         // If the paid endpoint redirected us cross-origin (typical of paid
@@ -279,6 +299,8 @@ export class BsvPaymentHandler {
       return getErrorPage(402)
     } catch {
       return getErrorPage(402)
+    } finally {
+      endTotal()
     }
   }
 


### PR DESCRIPTION
## Summary

Rebased onto **#107** (native secp256k1 + native tx engine, now in `master`). #107 is a strict superset of this branch's original ECDSA-only native-secp work on iOS, so that stack (`modules/native-secp256k1`, the Metro-resolver alias, `utils/crypto/*`, `@noble/secp256k1` v3) is **dropped in favour of #107's full-surface native engine**. What remains here is a small set of **orthogonal, app-level 402 payment wins** that stack on top of #107's crypto, plus a version marker.

This branch now contains exactly two commits on top of `master`.

## What's included

- **Parallelize 402 key derivation** (`utils/webview/bsvPaymentHandler.ts`) — the BRC-29 derived key and the sender identity key are independent, so derive them with `Promise.all` instead of serially, removing one key-derivation round-trip from the pay hot path. Also adds dev-only `402.*` phase instrumentation (`derive` / `identity` / `createAction` / `signAction` / `paidGet` / `total`).
- **Gate the spend-auth log** (`context/WalletContext.tsx`) — the per-request `console.log` in `spendingAuthorizationCallback` fired **during** `createAction` (the callback runs mid-build) and flushed over the JS↔native bridge on every spend. Gating it behind `__DEV__` cut warm `createAction` ~704 → ~547 ms on device.
- **Tier the CWI scheduler** (`app/index.tsx`) — L0 (`getVersion`/`getNetwork`/`isAuthenticated`/`waitForAuthentication`) and L1 (crypto) BRC-100 methods now skip the `InteractionManager` yield via a `CWI_NO_YIELD` set. dApps storm these on page load; they touch no storage and don't contend with chrome the way an L3 `createAction` does.
- **ARC broadcast-status handling** (`services/arcadeBroadcastProvider.ts` + test) — treat Arcade's `RECEIVED`/`202` and `SEEN_*` as broadcast success (matching the toolbox's built-in ARC provider) instead of failing over to WoC after Arcade already accepted the tx.
- Docs: `docs/402_PAYMENTS.md`, `docs/WALLET_PERFORMANCE_ARCHITECTURE.md`.
- `chore`: version bump to **1.6.0** (build marker).

## Measured on-device (with #107 native crypto active)

Native crypto makes the EC micro-ops sub-frame — 402 `derive`+`identity` now **< 16 ms each** (were 24–36 ms). But the 402 *pay* wall-clock is dominated by I/O + the merchant's server-side payment claim (`paidGet` ~16 s, `wallet.internalizeAction` → remote wallet-storage broadcaster), which no app-side change moves. Native crypto's real wins are in the crypto-heavy flows measured in #107's `BENCHMARKS.md` (multi-input `Transaction.sign`, BRC-42 derivation storms). These 402 wins target JS-thread responsiveness and the app's own ~0.5–1.5 s `createAction` slice.

## Verified

- Rebased clean onto `master` (zero merge conflicts, fast-forward).
- Combined build runs on the iOS simulator with #107 native crypto active (`[SecpNative]`/`[EngineNative] installed`); auto-approved 402 payments succeed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
